### PR TITLE
feat: remove nav bar styling and simplify app bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For Android 10 (API level 29) and above, you should also add:
 | `customConnectedIcon`       | `Int`     | Custom drawable resource ID for connected network status    |
 | `customDisconnectedIcon`    | `Int`     | Custom drawable resource ID for disconnected network status |
 | `inboxName`                 | `String`  | Custom inbox name displayed in the app bar                 |
+| `inboxNameFontSize`         | `Float`   | Font size for the inbox name in SP (default: 16f)         |
 | `disableEditor`             | `Boolean` | Disable the message editor (chat becomes read-only)        |
 | `editorDisableUpload`       | `Boolean` | Disable file upload functionality in the editor            |
 
@@ -126,6 +127,7 @@ val config = ChatwootConfiguration(
     customConnectedIcon = R.drawable.ic_custom_online,
     customDisconnectedIcon = R.drawable.ic_custom_offline,
     inboxName = "Customer Support",
+    inboxNameFontSize = 18f, // Larger font size
     disableEditor = false, // Allow messaging
     editorDisableUpload = false // Allow file uploads
 )

--- a/example/src/main/java/com/chatwoot/example/MainActivity.kt
+++ b/example/src/main/java/com/chatwoot/example/MainActivity.kt
@@ -516,6 +516,7 @@ fun ChatwootConfigScreen(onOpenChat: (ChatwootConfiguration, Int) -> Unit) {
                         customConnectedIcon = selectedConnectedIcon,
                         customDisconnectedIcon = selectedDisconnectedIcon,
                         inboxName = inboxName,
+                        inboxNameFontSize = 18f, // Example: slightly larger font
                         disableEditor = disableEditor,
                         editorDisableUpload = editorDisableUpload
                     )

--- a/src/main/java/com/chatwoot/sdk/ChatwootActivity.kt
+++ b/src/main/java/com/chatwoot/sdk/ChatwootActivity.kt
@@ -160,8 +160,9 @@ class ChatwootActivity : AppCompatActivity() {
             // Set up network status icons - will be updated by network monitoring
             setupNetworkStatusIcons()
 
-            // Set inbox name
+            // Set inbox name and font size
             inboxName.text = config.inboxName
+            inboxName.textSize = config.inboxNameFontSize
         }
     }
 

--- a/src/main/java/com/chatwoot/sdk/ChatwootActivity.kt
+++ b/src/main/java/com/chatwoot/sdk/ChatwootActivity.kt
@@ -28,7 +28,6 @@ import android.net.NetworkRequest
 
 class ChatwootActivity : AppCompatActivity() {
     private lateinit var binding: ActivityChatwootBinding
-    private var profile: ChatwootProfile? = null
     private lateinit var config: ChatwootConfiguration
     private var conversationId: Int = 0
     private lateinit var connectivityManager: ConnectivityManager
@@ -148,10 +147,8 @@ class ChatwootActivity : AppCompatActivity() {
                 // Adjust text color based on background brightness
                 val isLightColor = isColorLight(color)
                 val textColor = if (isLightColor) Color.BLACK else Color.WHITE
-                val subtitleColor = if (isLightColor) Color.parseColor("#666666") else Color.parseColor("#CCCCCC")
                 
-                profileName.setTextColor(textColor)
-                inboxName.setTextColor(subtitleColor)
+                inboxName.setTextColor(textColor)
 
                 // Adjust back button tint
                 backButton.drawable?.setTint(textColor)
@@ -163,44 +160,11 @@ class ChatwootActivity : AppCompatActivity() {
             // Set up network status icons - will be updated by network monitoring
             setupNetworkStatusIcons()
 
-            // Set default profile name and inbox name
-            profileName.text = "Chat User"
+            // Set inbox name
             inboxName.text = config.inboxName
-
-            // Update profile when available
-            ChatwootSDK.getProfile { newProfile ->
-                runOnUiThread {
-                    updateProfile(newProfile)
-                }
-            }
         }
     }
 
-    private fun updateProfile(profile: ChatwootProfile?) {
-        profile?.let {
-            binding.profileName.text = it.name
-
-            // Load avatar if available
-            it.avatarUrl?.let { url ->
-                binding.avatarImage.load(url) {
-                    transformations(CircleCropTransformation())
-                }
-            } ?: run {
-                // Show initials avatar
-                binding.avatarImage.setImageDrawable(
-                    TextDrawable.create(getInitials(it.name))
-                )
-            }
-        }
-    }
-
-    private fun getInitials(name: String): String {
-        return name.split(" ")
-            .take(2)
-            .mapNotNull { it.firstOrNull()?.toString() }
-            .joinToString("")
-            .uppercase()
-    }
 
     private fun isColorLight(color: Int): Boolean {
         val red = Color.red(color)

--- a/src/main/java/com/chatwoot/sdk/ChatwootActivity.kt
+++ b/src/main/java/com/chatwoot/sdk/ChatwootActivity.kt
@@ -110,26 +110,22 @@ class ChatwootActivity : AppCompatActivity() {
         // Make content draw under system bars
         WindowCompat.setDecorFitsSystemWindows(window, true)
 
-        // Set status bar and navigation bar colors
+        // Set status bar color
         val customColor = config.customColor
         if (customColor != null) {
             window.statusBarColor = customColor
-            window.navigationBarColor = customColor
 
-            // Adjust system bar icon colors based on custom color brightness
+            // Adjust status bar icon color based on custom color brightness
             val isLightColor = isColorLight(customColor)
             WindowCompat.getInsetsController(window, window.decorView).apply {
                 isAppearanceLightStatusBars = isLightColor
-                isAppearanceLightNavigationBars = isLightColor
             }
         } else {
             window.statusBarColor = Color.TRANSPARENT
-            window.navigationBarColor = Color.TRANSPARENT
 
-            // Make system bar icons dark for transparent bars
+            // Make status bar icons dark for transparent bar
             WindowCompat.getInsetsController(window, window.decorView).apply {
                 isAppearanceLightStatusBars = true
-                isAppearanceLightNavigationBars = true
             }
         }
     }
@@ -148,7 +144,6 @@ class ChatwootActivity : AppCompatActivity() {
             config.customColor?.let { color ->
                 statusBarSpace.setBackgroundColor(color)
                 toolbar.setBackgroundColor(color)
-                navigationBarSpace.setBackgroundColor(color)
 
                 // Adjust text color based on background brightness
                 val isLightColor = isColorLight(color)

--- a/src/main/java/com/chatwoot/sdk/models/ChatwootModels.kt
+++ b/src/main/java/com/chatwoot/sdk/models/ChatwootModels.kt
@@ -15,6 +15,7 @@ data class ChatwootConfiguration(
     val customConnectedIcon: Int? = null,
     val customDisconnectedIcon: Int? = null,
     val inboxName: String = "Resident Name",
+    val inboxNameFontSize: Float = 16f,
     val disableEditor: Boolean = false,
     val editorDisableUpload: Boolean = false
 ) : Parcelable

--- a/src/main/res/layout/activity_chatwoot.xml
+++ b/src/main/res/layout/activity_chatwoot.xml
@@ -49,51 +49,26 @@
                         android:contentDescription="Back"
                         android:padding="12dp" />
 
-                    <com.google.android.material.imageview.ShapeableImageView
-                        android:id="@+id/avatarImage"
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
-                        android:layout_marginStart="4dp"
-                        app:shapeAppearanceOverlay="@style/CircleImageView"
-                        android:background="@color/avatar_background" />
-
-                    <LinearLayout
+                    <TextView
+                        android:id="@+id/inboxName"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="12dp"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/profileName"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:ellipsize="end"
-                            android:maxLines="1"
-                            android:textColor="@android:color/black"
-                            android:textSize="16sp"
-                            android:textStyle="bold" />
-
-                        <TextView
-                            android:id="@+id/inboxName"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:ellipsize="end"
-                            android:maxLines="1"
-                            android:textColor="#666666"
-                            android:textSize="12sp"
-                            android:text="Resident Name" />
-
-                    </LinearLayout>
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textColor="@android:color/black"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:gravity="center"
+                        android:text="Inbox Name" />
 
                     <ImageView
                         android:id="@+id/networkStatusIcon"
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_marginStart="8dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:src="@drawable/ic_network_connected"
                         android:contentDescription="Network Status"
-                        android:padding="2dp" />
+                        android:padding="12dp" />
 
                 </LinearLayout>
 


### PR DESCRIPTION
- remove styling nav bar based on custom color
- show only inbox name on app bar (remove chat user name and avatar)
- allow setting custom fontsize for inbox name with `inboxNameFontSize` parameter

<img width="495" alt="image" src="https://github.com/user-attachments/assets/dbbfa7e7-a6cf-4561-b5c3-414b9b41801f" />
